### PR TITLE
export-users-by-course command added

### DIFF
--- a/moodlecli/main.py
+++ b/moodlecli/main.py
@@ -225,7 +225,7 @@ def import_bulk(source_course_id, targetcourses_csv):
 @click.argument('bucket_name')
 @click.argument('key')
 def export_grades(source_course_id, bucket_name, key):
-    """Output to CSV the grades for a given course"""
+    """Output to JSON the grades for a given course into a s3 bucket"""
     moodle = get_moodle_client()
 
     grades = moodle.get_course_grades(
@@ -233,3 +233,19 @@ def export_grades(source_course_id, bucket_name, key):
     )
 
     aws.put_json_data(grades, bucket_name, key)
+
+
+@cli.command()
+@click.argument('source_course_id')
+@click.argument('bucket_name')
+@click.argument('key')
+def export_users_by_course(source_course_id, bucket_name, key):
+    """Output to JSON the users (and their info) for a given course to s3
+    bucket"""
+    moodle = get_moodle_client()
+
+    users = moodle.get_users_by_course(
+        source_course_id
+    )
+
+    aws.put_json_data(users, bucket_name, key)

--- a/moodlecli/moodle.py
+++ b/moodlecli/moodle.py
@@ -17,6 +17,8 @@ MOODLE_FUNC_SET_SELF_ENROLMENT_METHOD_KEY = \
     "local_raisecli_set_self_enrolment_method_key"
 MOODLE_FUNC_GRADEREPORT_USER_GET_GRADE_ITEMS = \
     "gradereport_user_get_grade_items"
+MOODLE_FUNC_CORE_ENROL_GET_ENROLLED_USERS = \
+    "core_enrol_get_enrolled_users"
 
 
 def convert_moodle_params(data, prefix=""):
@@ -206,6 +208,12 @@ class MoodleClient:
             'courseid': course_id
         }
         return self._get(MOODLE_FUNC_GRADEREPORT_USER_GET_GRADE_ITEMS, data)
+
+    def get_users_by_course(self, course_id):
+        data = {
+            "courseid": course_id
+        }
+        return self._get(MOODLE_FUNC_CORE_ENROL_GET_ENROLLED_USERS, data)
 
     def get_course_enrolment_url(self, course_id):
         return f"{self.moodle_url}/enrol/index.php?id={course_id}"

--- a/tests/test_moodle.py
+++ b/tests/test_moodle.py
@@ -333,3 +333,24 @@ def test_get_course_grades(mocker):
     )
 
     assert grades_json == [{}]
+
+
+def test_get_users_by_course(mocker):
+    session_mock = mocker.Mock()
+    session_mock.get.return_value.json.return_value = [{}]
+    client = moodle.MoodleClient(
+        session_mock, TEST_MOODLE_URL, TEST_MOODLE_TOKEN
+    )
+    users_json = client.get_users_by_course(2)
+
+    session_mock.get.assert_called_once_with(
+        f"{TEST_MOODLE_URL}{moodle.MOODLE_WEBSERVICE_PATH}",
+        params={
+            "courseid": 2,
+            "wsfunction": moodle.MOODLE_FUNC_CORE_ENROL_GET_ENROLLED_USERS,
+            "moodlewsrestformat": "json",
+            "wstoken": TEST_MOODLE_TOKEN
+        }
+    )
+
+    assert users_json == [{}]


### PR DESCRIPTION
This PR creates a new CLI command for exporting user profiles to s3 storage