### PR TITLE
courses now in a table

### DIFF
--- a/moodlecli/main.py
+++ b/moodlecli/main.py
@@ -74,7 +74,8 @@ def courses():
     """Get list of courses"""
     moodle = get_moodle_client()
     res = moodle.get_courses()
-    click.echo(json.dumps(res, indent=4))
+    table = utils.stylize_courses(res)
+    click.echo(table)
 
 
 @cli.command()

--- a/moodlecli/utils.py
+++ b/moodlecli/utils.py
@@ -1,5 +1,6 @@
 import string
 import random
+from prettytable import PrettyTable
 
 CSV_INST_FNAME = 'instructor_firstname'
 CSV_INST_LNAME = 'instructor_lastname'
@@ -97,6 +98,20 @@ def create_or_get_user(moodle_client, firstname, lastname, email, auth):
         )
         user_id = new_user["id"]
     return user_id
+
+
+def stylize_courses(courses_json):
+    t = PrettyTable()
+    fields = ['fullname', 'id', 'visible', 'categoryid']
+    t.field_names = fields
+    for course in courses_json:
+        row = []
+        for col in fields:
+            row.append(course[col])
+        t.add_row(row)
+
+    t.align["fullname"] = "l"
+    return t.get_string(sortby='id')
 
 
 def setup_duplicate_course(

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,6 +8,7 @@ install_requires =
     click==8.0.3
     requests==2.26.0
     boto3==1.20.52
+    prettytable==3.1.0
 
 
 [options.extras_require]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -116,7 +116,10 @@ def test_course_bulk_setup(moodle_requests_mock, tmp_path):
 
 
 def test_courses(requests_mock):
-    test_json = {"foo": "bar"}
+    test_json = [{'fullname': 'foo',
+                  'id': '1',
+                  'visible': '1',
+                  'categoryid': '1'}]
     runner = CliRunner()
     requests_mock.get(f'{TEST_MOODLE_URL}{moodle.MOODLE_WEBSERVICE_PATH}',
                       json=test_json)
@@ -124,7 +127,7 @@ def test_courses(requests_mock):
     result = runner.invoke(cli, ['courses'],
                            env=TEST_ENV)
     assert result.exit_code == 0
-    assert json.loads(result.output) == test_json
+    assert result.output == utils.stylize_courses(test_json) + '\n'
 
 
 def test_enable_self_enrolment_method(moodle_requests_mock):


### PR DESCRIPTION
The `courses` command now prints an ascii table of all courses with their fullname, id, visible, and categoryid variables as columns.