### PR TITLE
Bulk grade + user upload to s3 cmds added

### DIFF
--- a/moodlecli/moodle.py
+++ b/moodlecli/moodle.py
@@ -203,7 +203,7 @@ class MoodleClient:
         }
         return self._post(MOODLE_FUNC_ENROL_USER, data)
 
-    def get_course_grades(self, course_id):
+    def get_grades_by_course(self, course_id):
         data = {
             'courseid': course_id
         }

--- a/moodlecli/utils.py
+++ b/moodlecli/utils.py
@@ -82,6 +82,13 @@ def import_bulk_input_csv_fieldnames():
     ]
 
 
+def bulk_export_csv_course_ids():
+    """Return array of fieldnames used in output CSV for bulk export"""
+    return{
+        CSV_COURSE_ID
+    }
+
+
 def create_or_get_user(moodle_client, firstname, lastname, email, auth):
     """Create a user account if it doesn't exist and return user ID"""
     existing_user = moodle_client.get_user_by_email(

--- a/tests/test_moodle.py
+++ b/tests/test_moodle.py
@@ -320,7 +320,7 @@ def test_get_course_grades(mocker):
     client = moodle.MoodleClient(
         session_mock, TEST_MOODLE_URL, TEST_MOODLE_TOKEN
     )
-    grades_json = client.get_course_grades(2)
+    grades_json = client.get_grades_by_course(2)
 
     session_mock.get.assert_called_once_with(
         f"{TEST_MOODLE_URL}{moodle.MOODLE_WEBSERVICE_PATH}",


### PR DESCRIPTION
This PR adds two commands `export-users-bulk` and `export-grades-bulk` which allow an administrator with the CLI to export all user details from all courses to s3 / export all grade details from all courses to s3 - respectively 